### PR TITLE
feat: update Django and Python support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - "3.7"
-          - "3.8"
           - "3.9"
           - "3.10"
           - "3.11"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
           - "3.9"
           - "3.10"
           - "3.11"
+          - "3.12"
     runs-on: ubuntu-20.04
     services:
       postgres:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
           - "3.11"
           - "3.12"
           - "3.13"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     services:
       postgres:
         image: postgres:14

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-20.04
     services:
       postgres:
-        image: postgres:13
+        image: postgres:14
         ports:
           - 5432:5432
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
           - "3.10"
           - "3.11"
           - "3.12"
+          - "3.13"
     runs-on: ubuntu-20.04
     services:
       postgres:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
           - "3.8"
           - "3.9"
           - "3.10"
+          - "3.11"
     runs-on: ubuntu-20.04
     services:
       postgres:

--- a/migrate_sql/management/commands/makemigrations.py
+++ b/migrate_sql/management/commands/makemigrations.py
@@ -5,6 +5,7 @@ into regular Django migrations.
 
 import sys
 
+import django
 from django.core.management.commands.makemigrations import Command as MakeMigrationsCommand
 from django.db.migrations.loader import MigrationLoader
 from django.db.migrations import Migration
@@ -21,7 +22,8 @@ class Command(MakeMigrationsCommand):
 
     @no_translations
     def handle(self, *app_labels, **options):
-
+        if django.VERSION >= (4, 1):
+            self.written_files = []
         self.verbosity = options.get('verbosity')
         self.interactive = options.get('interactive')
         self.dry_run = options.get('dry_run', False)
@@ -31,6 +33,11 @@ class Command(MakeMigrationsCommand):
         self.exit_code = options.get('exit_code', False)
         self.include_header = options.get('include_header', True)
         check_changes = options.get('check_changes', False)
+        if django.VERSION >= (4, 1):
+            self.scriptable = options["scriptable"]
+            # If logs and prompts are diverted to stderr, remove the ERROR style.
+            if self.scriptable:
+                self.stderr.style_func = None
 
         # Make sure the app they asked for exists
         app_labels = set(app_labels)

--- a/migrate_sql/operations.py
+++ b/migrate_sql/operations.py
@@ -1,5 +1,8 @@
+import django
 from django.db.migrations.operations import RunSQL
 from django.db.migrations.operations.base import Operation
+if django.VERSION >= (5, 1):
+    from django.db.migrations.operations.base import OperationCategory
 
 from migrate_sql.graph import SQLStateGraph
 from migrate_sql.config import SQLItem
@@ -20,6 +23,10 @@ class AlterSQLState(MigrateSQLMixin, Operation):
     Alters in-memory state of SQL item.
     This operation is generated separately from others since it does not affect database.
     """
+
+    if django.VERSION >= (5, 1):
+        category = OperationCategory.PYTHON
+
     def describe(self):
         return 'Alter SQL state "{name}"'.format(name=self.name)
 
@@ -86,6 +93,10 @@ class BaseAlterSQL(MigrateSQLMixin, RunSQL):
     """
     Base class for operations that alter database.
     """
+
+    if django.VERSION >= (5, 1):
+        category = OperationCategory.SQL
+
     def __init__(self, name, sql, reverse_sql=None, state_operations=None, hints=None):
         super(BaseAlterSQL, self).__init__(sql, reverse_sql=reverse_sql,
                                            state_operations=state_operations, hints=hints)
@@ -98,6 +109,10 @@ class BaseAlterSQL(MigrateSQLMixin, RunSQL):
 
 
 class ReverseAlterSQL(BaseAlterSQL):
+
+    if django.VERSION >= (5, 1):
+        category = OperationCategory.ALTERATION
+
     def describe(self):
         return 'Reverse alter SQL "{name}"'.format(name=self.name)
 
@@ -106,6 +121,10 @@ class AlterSQL(BaseAlterSQL):
     """
     Updates SQL item with a new version.
     """
+
+    if django.VERSION >= (5, 1):
+        category = OperationCategory.ALTERATION
+
     def __init__(self, name, sql, reverse_sql=None, state_operations=None, hints=None,
                  state_reverse_sql=None):
         """
@@ -150,6 +169,10 @@ class CreateSQL(BaseAlterSQL):
     """
     Creates new SQL item in database.
     """
+
+    if django.VERSION >= (5, 1):
+        category = OperationCategory.ADDITION
+
     def describe(self):
         return 'Create SQL "{name}"'.format(name=self.name)
 
@@ -183,6 +206,10 @@ class DeleteSQL(BaseAlterSQL):
     """
     Deltes SQL item from database.
     """
+
+    if django.VERSION >= (5, 1):
+        category = OperationCategory.REMOVAL
+
     def describe(self):
         return 'Delete SQL "{name}"'.format(name=self.name)
 

--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -1,2 +1,3 @@
-psycopg2>=2.6.1,<2.9
+psycopg2>=2.6.1,<2.9;python_version<"3.11"
+psycopg2>=2.9;python_version>="3.11"
 coverage==4.0.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-Django>=1.8
+Django>=3.2

--- a/setup.py
+++ b/setup.py
@@ -67,6 +67,7 @@ setup(
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
         'Framework :: Django :: 3.2',
         'Framework :: Django :: 4.0',
         'Framework :: Django :: 4.1',

--- a/setup.py
+++ b/setup.py
@@ -66,10 +66,6 @@ setup(
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
-        'Framework :: Django :: 2.1',
-        'Framework :: Django :: 2.2',
-        'Framework :: Django :: 3.0',
-        'Framework :: Django :: 3.1',
         'Framework :: Django :: 3.2',
         'Framework :: Django :: 4.0',
         'Framework :: Django :: 4.1',
@@ -77,6 +73,6 @@ setup(
     ],
     tests_require=['tox'],
     cmdclass={'test': Tox},
-    install_requires=[],
+    install_requires=["Django>=3.2"],
     python_requires=">=3.9",
 )

--- a/setup.py
+++ b/setup.py
@@ -72,6 +72,7 @@ setup(
         'Framework :: Django :: 4.1',
         'Framework :: Django :: 4.2',
         'Framework :: Django :: 5.0',
+        'Framework :: Django :: 5.1',
     ],
     tests_require=['tox'],
     cmdclass={'test': Tox},

--- a/setup.py
+++ b/setup.py
@@ -70,6 +70,7 @@ setup(
         'Framework :: Django :: 4.0',
         'Framework :: Django :: 4.1',
         'Framework :: Django :: 4.2',
+        'Framework :: Django :: 5.0',
     ],
     tests_require=['tox'],
     cmdclass={'test': Tox},

--- a/setup.py
+++ b/setup.py
@@ -66,6 +66,7 @@ setup(
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
         'Framework :: Django :: 3.2',
         'Framework :: Django :: 4.0',
         'Framework :: Django :: 4.1',

--- a/setup.py
+++ b/setup.py
@@ -74,6 +74,7 @@ setup(
         'Framework :: Django :: 3.1',
         'Framework :: Django :: 3.2',
         'Framework :: Django :: 4.0',
+        'Framework :: Django :: 4.1',
     ],
     tests_require=['tox'],
     cmdclass={'test': Tox},

--- a/setup.py
+++ b/setup.py
@@ -63,9 +63,6 @@ setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',
         'Natural Language :: English',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
@@ -81,4 +78,5 @@ setup(
     tests_require=['tox'],
     cmdclass={'test': Tox},
     install_requires=[],
+    python_requires=">=3.9",
 )

--- a/setup.py
+++ b/setup.py
@@ -68,6 +68,7 @@ setup(
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
         'Framework :: Django :: 2.1',
         'Framework :: Django :: 2.2',
         'Framework :: Django :: 3.0',

--- a/setup.py
+++ b/setup.py
@@ -76,6 +76,7 @@ setup(
         'Framework :: Django :: 3.2',
         'Framework :: Django :: 4.0',
         'Framework :: Django :: 4.1',
+        'Framework :: Django :: 4.2',
     ],
     tests_require=['tox'],
     cmdclass={'test': Tox},

--- a/setup.py
+++ b/setup.py
@@ -74,6 +74,7 @@ setup(
         'Framework :: Django :: 4.2',
         'Framework :: Django :: 5.0',
         'Framework :: Django :: 5.1',
+        'Framework :: Django :: 5.2',
     ],
     tests_require=['tox'],
     cmdclass={'test': Tox},

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 envlist =
-    py311-django{41}
-    py310-django{32,40,41}
-    py39-django{30,31,32,40,41}
-    py38-django{22,30,31,32,40,41}
+    py311-django{41,42}
+    py310-django{32,40,41,42}
+    py39-django{30,31,32,40,41,42}
+    py38-django{22,30,31,32,40,41,42}
     py37-django{21,22,30,31,32}
     py36-django{21,22,30,31,32}
 
@@ -19,6 +19,7 @@ deps=
     django32: Django>=3.2,<4.0
     django40: Django>=4.0,<4.1
     django41: Django>=4.1,<4.2
+    django42: Django>=4.2,<5.0
     -rrequirements-testing.txt
 
 whitelist_externals = coverage

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 envlist =
-    py313-django{51}
-    py312-django{42,50,51}
-    py311-django{41,42,50,51}
-    py310-django{32,40,41,42,50,51}
+    py313-django{51,52}
+    py312-django{42,50,51,52}
+    py311-django{41,42,50,51,52}
+    py310-django{32,40,41,42,50,51,52}
     py39-django{32,40,41,42}
 
 [testenv]
@@ -16,6 +16,7 @@ deps=
     django42: Django>=4.2,<5.0
     django50: Django>=5.0,<5.1
     django51: Django>=5.1,<5.2
+    django52: Django>=5.2,<6.0
     -rrequirements-testing.txt
 
 whitelist_externals = coverage

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,6 @@
 [tox]
 envlist =
+    py313-django{51}
     py312-django{42,50,51}
     py311-django{41,42,50,51}
     py310-django{32,40,41,42,50,51}

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist =
-    py312-django{42,50}
-    py311-django{41,42,50}
-    py310-django{32,40,41,42,50}
+    py312-django{42,50,51}
+    py311-django{41,42,50,51}
+    py310-django{32,40,41,42,50,51}
     py39-django{32,40,41,42}
 
 [testenv]
@@ -14,6 +14,7 @@ deps=
     django41: Django>=4.1,<4.2
     django42: Django>=4.2,<5.0
     django50: Django>=5.0,<5.1
+    django51: Django>=5.1,<5.2
     -rrequirements-testing.txt
 
 whitelist_externals = coverage

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
-    py311-django{41,42}
-    py310-django{32,40,41,42}
+    py311-django{41,42,50}
+    py310-django{32,40,41,42,50}
     py39-django{32,40,41,42}
 
 [testenv]
@@ -12,6 +12,7 @@ deps=
     django40: Django>=4.0,<4.1
     django41: Django>=4.1,<4.2
     django42: Django>=4.2,<5.0
+    django50: Django>=5.0,<5.1
     -rrequirements-testing.txt
 
 whitelist_externals = coverage

--- a/tox.ini
+++ b/tox.ini
@@ -3,9 +3,6 @@ envlist =
     py311-django{41,42}
     py310-django{32,40,41,42}
     py39-django{30,31,32,40,41,42}
-    py38-django{22,30,31,32,40,41,42}
-    py37-django{21,22,30,31,32}
-    py36-django{21,22,30,31,32}
 
 [testenv]
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -2,17 +2,12 @@
 envlist =
     py311-django{41,42}
     py310-django{32,40,41,42}
-    py39-django{30,31,32,40,41,42}
+    py39-django{32,40,41,42}
 
 [testenv]
 commands =
     python runtests.py
 deps=
-    django20: Django>=2.0,<2.1
-    django21: Django>=2.1,<2.2
-    django22: Django>=2.2,<3.0
-    django30: Django>=3.0,<3.1
-    django31: Django>=3.1,<3.2
     django32: Django>=3.2,<4.0
     django40: Django>=4.0,<4.1
     django41: Django>=4.1,<4.2

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist =
-    py310-django{32,40}
-    py39-django{30,31,32,40}
-    py38-django{22,30,31,32,40}
+    py310-django{32,40,41}
+    py39-django{30,31,32,40,41}
+    py38-django{22,30,31,32,40,41}
     py37-django{21,22,30,31,32}
     py36-django{21,22,30,31,32}
 
@@ -17,6 +17,7 @@ deps=
     django31: Django>=3.1,<3.2
     django32: Django>=3.2,<4.0
     django40: Django>=4.0,<4.1
+    django41: Django>=4.1,<4.2
     -rrequirements-testing.txt
 
 whitelist_externals = coverage

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,6 @@
 [tox]
 envlist =
+    py312-django{42,50}
     py311-django{41,42,50}
     py310-django{32,40,41,42,50}
     py39-django{32,40,41,42}

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,6 @@
 [tox]
 envlist =
+    py311-django{41}
     py310-django{32,40,41}
     py39-django{30,31,32,40,41}
     py38-django{22,30,31,32,40,41}


### PR DESCRIPTION
- Add all version up to Django 5.2 and Python 3.13
- Drop support for all EOL Python <3.9
- Drop support for Django <3.2 for now, leaving some overlap in supported versions with previous releases