### PR TITLE
fix: update PSR config to fix automated releases

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,7 +126,7 @@ allow_untyped_defs = true
 version_toml = [ "pyproject.toml:project.version" ]
 tag_format = "v{version}"
 version_variables = [
-  "src/migrate_sql/__init__.py:__version__"
+  "src/django_migrate_sql/__init__.py:__version__"
 ]
 build_command = """
 pip install uv


### PR DESCRIPTION
### Description of change

Update config for Python Semantic Release to fix automated releases.

### Pull-Request Checklist

- [x] Code is up-to-date with the `main` branch
- [x] This pull request follows the [contributing guidelines](https://github.com/browniebroke/django-migrate-sql-deux/blob/main/CONTRIBUTING.md).
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/), such as "fix(api): prevent racing of requests".

> - If pre-commit.ci is failing, try `pre-commit run -a` for further information.
> - If CI / test is failing, try `uv run pytest` for further information.
