### PR TITLE
ci: fix coverage reporting with parallel runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,8 @@ jobs:
         shell: bash
       - run: tox -f py$(echo ${{ matrix.python-version }} | tr -d .)
         shell: bash
+      - run: python -m coverage combine
+        shell: bash
       - uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
         shell: bash
       - run: tox -f py$(echo ${{ matrix.python-version }} | tr -d .)
         shell: bash
-      - run: python -m coverage combine
+      - run: uv run coverage combine
         shell: bash
       - uses: codecov/codecov-action@v5
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,9 @@ jobs:
         shell: bash
       - run: tox -f py$(echo ${{ matrix.python-version }} | tr -d .)
         shell: bash
-      - run: uv run coverage combine
+      - run: |
+          uv run coverage combine
+          uv run coverage xml
         shell: bash
       - uses: codecov/codecov-action@v5
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,8 +43,8 @@ dev = [
   "psycopg2>=2.9.10,<2.10;python_version<'3.11'",
   "psycopg2>=2.9;python_version>='3.11'",
   "pytest>=8,<9",
-  "pytest-cov>=6,<7",
   "pytest-django>=4.5,<5",
+  "coverage",
 ]
 
 [tool.ruff]
@@ -93,15 +93,13 @@ lint.isort.known-first-party = [ "django_migrate_sql", "tests" ]
 addopts = """\
     -v
     -Wdefault
-    --cov=django_migrate_sql
-    --cov-report=term
-    --cov-report=xml
     --ds=tests.settings
     """
 pythonpath = [ "src" ]
 
 [tool.coverage.run]
 branch = true
+parallel = true
 
 [tool.coverage.report]
 exclude_lines = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,6 +100,16 @@ pythonpath = [ "src" ]
 [tool.coverage.run]
 branch = true
 parallel = true
+source = [
+  "django_migrate_sql",
+  "tests",
+]
+
+[tool.coverage.paths]
+source = [
+  "src",
+  ".tox/**/site-packages",
+]
 
 [tool.coverage.report]
 exclude_lines = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,7 +102,6 @@ branch = true
 parallel = true
 source = [
   "django_migrate_sql",
-  "tests",
 ]
 
 [tool.coverage.paths]

--- a/tox.ini
+++ b/tox.ini
@@ -21,4 +21,5 @@ deps =
     django42: Django>=4.2,<5.0
 commands =
     python \
+      -m coverage run \
       -m pytest {posargs:tests}

--- a/uv.lock
+++ b/uv.lock
@@ -102,11 +102,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/08/b8/7ddd1e8ba9701dea08ce22029917140e6f66a859427406579fd8d0ca7274/coverage-7.9.1-py3-none-any.whl", hash = "sha256:66b974b145aa189516b6bf2d8423e888b742517d37872f6ee4c5be0073bd9a3c", size = 204000, upload-time = "2025-06-13T13:02:27.173Z" },
 ]
 
-[package.optional-dependencies]
-toml = [
-    { name = "tomli", marker = "python_full_version <= '3.11'" },
-]
-
 [[package]]
 name = "django"
 version = "4.2.23"
@@ -153,9 +148,9 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "coverage" },
     { name = "psycopg2" },
     { name = "pytest" },
-    { name = "pytest-cov" },
     { name = "pytest-django" },
 ]
 
@@ -164,10 +159,10 @@ requires-dist = [{ name = "django", specifier = ">=4.2" }]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "coverage" },
     { name = "psycopg2", marker = "python_full_version < '3.11'", specifier = ">=2.9.10,<2.10" },
     { name = "psycopg2", marker = "python_full_version >= '3.11'", specifier = ">=2.9" },
     { name = "pytest", specifier = ">=8,<9" },
-    { name = "pytest-cov", specifier = ">=6,<7" },
     { name = "pytest-django", specifier = ">=4.5,<5" },
 ]
 
@@ -252,20 +247,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/fb/aa/405082ce2749be5398045152251ac69c0f3578c7077efc53431303af97ce/pytest-8.4.0.tar.gz", hash = "sha256:14d920b48472ea0dbf68e45b96cd1ffda4705f33307dcc86c676c1b5104838a6", size = 1515232, upload-time = "2025-06-02T17:36:30.03Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2f/de/afa024cbe022b1b318a3d224125aa24939e99b4ff6f22e0ba639a2eaee47/pytest-8.4.0-py3-none-any.whl", hash = "sha256:f40f825768ad76c0977cbacdf1fd37c6f7a468e460ea6a0636078f8972d4517e", size = 363797, upload-time = "2025-06-02T17:36:27.859Z" },
-]
-
-[[package]]
-name = "pytest-cov"
-version = "6.2.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "coverage", extra = ["toml"] },
-    { name = "pluggy" },
-    { name = "pytest" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/18/99/668cade231f434aaa59bbfbf49469068d2ddd945000621d3d165d2e7dd7b/pytest_cov-6.2.1.tar.gz", hash = "sha256:25cc6cc0a5358204b8108ecedc51a9b57b34cc6b8c967cc2c01a4e00d8a67da2", size = 69432, upload-time = "2025-06-12T10:47:47.684Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/bc/16/4ea354101abb1287856baa4af2732be351c7bee728065aed451b678153fd/pytest_cov-6.2.1-py3-none-any.whl", hash = "sha256:f5bc4c23f42f1cdd23c70b1dab1bbaef4fc505ba950d53e0081d0730dd7e86d5", size = 24644, upload-time = "2025-06-12T10:47:45.932Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### Description of change

The coverage report is wrong in Codecov, because we don't have `parallel = true`, and we run multiple versions on the same CI worker, so only the latest version of Django that runs is reported.

The project uses `pytest-cov` which does not work with this option:

> This plugin overrides the parallel option of coverage. Unless you also run coverage without pytest-cov it’s pointless to set those options in your .coveragerc.

Dropping this dependency in an attempt to get more accurate combined coverage.

### Pull-Request Checklist

- [x] Code is up-to-date with the `main` branch
- [x] This pull request follows the [contributing guidelines](https://github.com/browniebroke/django-migrate-sql-deux/blob/main/CONTRIBUTING.md).
- [x] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/), such as "fix(api): prevent racing of requests".